### PR TITLE
Refactor Unit Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "2.7"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: "pip install -r requirements.txt responses"
 # command to run tests
 script: python tests.py

--- a/influxdbds.py
+++ b/influxdbds.py
@@ -16,8 +16,8 @@ operator_symbols = {
 @lru_cache()
 def get_tags_and_field_keys(client, measurement_name, db_name):
     client.switch_database(db_name)
-    field_keys = tuple(f['fieldKey'] for f in client.query('show field keys')[measurement_name])
-    tag_keys = tuple(t['tagKey'] for t in client.query('show tag keys')[measurement_name])
+    field_keys = tuple(f['fieldKey'] for f in client.query('SHOW FIELD KEYS')[measurement_name])
+    tag_keys = tuple(t['tagKey'] for t in client.query('SHOW TAG KEYS')[measurement_name])
     return tuple(field_keys + tag_keys)
 
 
@@ -103,7 +103,7 @@ class InfluxDBMeasurement(EntityCollection):
             self._where_expression(),
             self._orderby_expression(),
             self._limit_expression(),
-        )
+        ).strip()
         logging.debug('Querying InfluxDB: {}'.format(q))
         result = self.container.client.query(q, database=self.db_name)
         fields = get_tags_and_field_keys(self.container.client, self.measurement_name, self.db_name)

--- a/influxdbds.py
+++ b/influxdbds.py
@@ -33,10 +33,11 @@ class InfluxDBEntityContainer(object):
         data source name in the format: influxdb://user:pass@host:port/
         supported schemes include https+influxdb:// and udp+influxdb://
     """
-    def __init__(self, container, dsn, **kwargs):
+    def __init__(self, container, dsn, topmax, **kwargs):
         self.container = container
         self.dsn = dsn
         self.client = influxdb.InfluxDBClient.from_DSN(self.dsn)
+        self._topmax = topmax
         for es in self.container.EntitySet:
             self.bind_entity_set(es)
 
@@ -59,7 +60,7 @@ class InfluxDBMeasurement(EntityCollection):
         self.db_name, self.measurement_name = self.entity_set.name.split('__')
         if self.db_name == u'internal':
             self.db_name = u'_internal'
-        self.topmax = 50
+        self.topmax = getattr(self.container, '_topmax', 50)
 
     @lru_cache()
     def _query_len(self):

--- a/influxdbmeta.py
+++ b/influxdbmeta.py
@@ -45,8 +45,8 @@ class InfluxDB(object):
 
     def fields(self, db_name):
         """returns a tuple of dicts where each dict has attributes (name, type, edm_type)"""
-        fields_rs = self.client.query('show field keys', database=db_name)
-        tags_rs = self.client.query('show tag keys', database=db_name)
+        fields_rs = self.client.query('SHOW FIELD KEYS', database=db_name)
+        tags_rs = self.client.query('SHOW TAG KEYS', database=db_name)
         # expand and deduplicate
         fields = set(tuple(f.items()) for f in chain(*chain(fields_rs, tags_rs)))
         fields = (dict(
@@ -75,9 +75,8 @@ class InfluxDB(object):
 
     @property
     def databases(self):
-        q = 'SHOW DATABASES'
-        rs = self.client.query(q)
-        return iter(rs.get_points())
+        rs = self.client.get_list_database()
+        return iter(rs)
 
 
 def gen_entity_set_xml(m):

--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ def start_server(c, doc):
     server.serve_forever()
 
 
-def make_sample_config():
+def get_sample_config():
     config = ConfigParser(allow_no_value=True)
     config.add_section('server')
     config.set('server', 'server_root', 'http://localhost:8080')
@@ -79,11 +79,15 @@ def make_sample_config():
     config.set('metadata', '; set autogenerate to "no" for quicker startup of the server if you know your influxdb structure has not changed')
     config.set('metadata', 'autogenerate', 'yes')
     config.set('metadata', '; metadata_file specifies the location of the metadata file to generate')
-    config.set('metadata', 'metadata_file', 'generated.xml')
+    config.set('metadata', 'metadata_file', 'test_metadata.xml')
     config.add_section('influxdb')
     config.set('influxdb', '; supported schemes include https+influxdb:// and udp+influxdb://')
     config.set('influxdb', 'dsn', 'influxdb://user:pass@localhost:8086')
     config.set('influxdb', 'max_items_per_query', '50')
+    return config
+
+def make_sample_config():
+    config = get_sample_config()
     sample_name = 'sample.conf'
     if os.path.exists(sample_name):
         raise FileExistsError(sample_name)

--- a/server.py
+++ b/server.py
@@ -42,7 +42,11 @@ def load_metadata(config):
     with open(metadata_filename, 'rb') as f:
         doc.ReadFromStream(f)
     container = doc.root.DataServices['InfluxDBSchema.InfluxDB']
-    InfluxDBEntityContainer(container=container, dsn=dsn)
+    try:
+        topmax = config.getint('influxdb', 'max_items_per_query')
+    except:
+        topmax = 50
+    InfluxDBEntityContainer(container=container, dsn=dsn, topmax=topmax)
     return doc
 
 
@@ -79,6 +83,7 @@ def make_sample_config():
     config.add_section('influxdb')
     config.set('influxdb', '; supported schemes include https+influxdb:// and udp+influxdb://')
     config.set('influxdb', 'dsn', 'influxdb://user:pass@localhost:8086')
+    config.set('influxdb', 'max_items_per_query', '50')
     sample_name = 'sample.conf'
     if os.path.exists(sample_name):
         raise FileExistsError(sample_name)

--- a/server.py
+++ b/server.py
@@ -14,6 +14,10 @@ from influxdbds import InfluxDBEntityContainer
 
 cache_app = None  #: our Server instance
 
+logging.basicConfig()
+logger = logging.getLogger("odata-influxdb")
+logger.setLevel(logging.INFO)
+
 
 class FileExistsError(IOError):
     def __init__(self, path):
@@ -29,6 +33,7 @@ def load_metadata(config):
     dsn = config.get('influxdb', 'dsn')
 
     if config.getboolean('metadata', 'autogenerate'):
+        logger.info("Generating OData metadata xml file from InfluxDB metadata")
         metadata = generate_metadata(dsn)
         with open(metadata_filename, 'wb') as f:
             f.write(metadata)
@@ -57,7 +62,7 @@ def configure_server(c, app):
 def start_server(c, doc):
     app = configure_app(c, doc)
     server = configure_server(c, app)
-    logging.info("Starting HTTP server on port %i..." % server.server_port)
+    logger.info("Starting HTTP server on port %i..." % server.server_port)
     # Respond to requests until process is killed
     server.serve_forever()
 

--- a/test_data/test_metadata.xml
+++ b/test_data/test_metadata.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<edmx:Edmx Version="1.0" xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"
+           xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.microsoft.com/ado/2007/06/edmx ">
+    <edmx:DataServices m:DataServiceVersion="2.0">
+        <Schema Namespace="InfluxDBSchema" xmlns="http://schemas.microsoft.com/ado/2006/04/edm"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://schemas.microsoft.com/ado/2006/04/edm ">
+    <EntityContainer Name="InfluxDB" m:IsDefaultEntityContainer="true">
+    <EntitySet Name="internal__measurement1" EntityType="InfluxDBSchema.internal__measurement1"/>
+<EntitySet Name="database1__measurement1" EntityType="InfluxDBSchema.database1__measurement1"/>
+    </EntityContainer>
+    <EntityType Name="internal__measurement1"><Key><PropertyRef Name="time" /></Key><Property Name="time" Type="Edm.DateTime" Nullable="false" />
+<Property Name="float_field" Type="Edm.Double" Nullable="true" />
+<Property Name="tag1" Type="Edm.String" Nullable="true" />
+<Property Name="int_field" Type="Edm.Int64" Nullable="true" />
+<Property Name="tag2" Type="Edm.String" Nullable="true" /></EntityType>
+<EntityType Name="database1__measurement1"><Key><PropertyRef Name="time" /></Key><Property Name="time" Type="Edm.DateTime" Nullable="false" />
+<Property Name="float_field" Type="Edm.Double" Nullable="true" />
+<Property Name="tag1" Type="Edm.String" Nullable="true" />
+<Property Name="int_field" Type="Edm.Int64" Nullable="true" />
+<Property Name="tag2" Type="Edm.String" Nullable="true" /></EntityType>
+    
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,11 @@ import random
 import re
 import unittest
 import os
-from responses import RequestsMock
+try:
+    from responses import RequestsMock
+except ImportError as e:
+    print('unit tests require responses library: try `pip install responses`')
+    raise e
 from server import generate_metadata, get_sample_config, load_metadata
 from pyslet.odata2 import core
 


### PR DESCRIPTION
This commit revises or removes all existing unit tests.

Unit testing is now dependent on the [`responses`](https://github.com/getsentry/responses) library for mock requests (no longer need a live influxdb server to test).

Client/Server tests have been removed until they can also use the mock request library.

A configuration option to change the LIMIT size for influxdb queries was added.
